### PR TITLE
Click + UTest: refactoring on default groups/commands + Refactoring logs capture in utests

### DIFF
--- a/cruft_helloworld/app.py
+++ b/cruft_helloworld/app.py
@@ -51,7 +51,12 @@ logger = logging.getLogger(__name__)
     # https://click.palletsprojects.com/en/7.x/options/#counting
     count=True,
 )
-@click.group(cls=DefaultGroup, default="hello-world", default_if_no_args=True)
+@click.group(
+    cls=DefaultGroup,
+    default="hello-world",
+    default_if_no_args=True,
+    invoke_without_command=True,
+)
 def cli(log_level, verbose):
     if verbose:
         default_logger_level = "INFO" if verbose == 1 else "DEBUG"
@@ -77,6 +82,9 @@ def hello_world(globe_emoji: Optional[str]):
     globe_emoji = globe_emoji or find_globe_emoji_from_external_ip()
     console.print(f"Hello :{globe_emoji}:")
 
+
+# https://www.python.org/dev/peps/pep-0484/
+cli.set_default_command(hello_world)  # type: ignore
 
 if __name__ == "__main__":
     cli()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1183,7 +1183,6 @@ click-default-group = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 colorlog = [
     {file = "colorlog-4.7.2-py2.py3-none-any.whl", hash = "sha256:0a9dcdba6cab68e8a768448b418a858d73c52b37b6e8dea2568296faece393bd"},
@@ -1617,8 +1616,6 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,16 @@
 import pytest
 
+from cruft_helloworld.app import cli
 from cruft_helloworld.services.globe_emoji_with_geoip import (
     find_globe_emoji_from_external_ip,
 )
 from cruft_helloworld.tools.enums import IsoCodeContinentEmoji
 from tests.tools.default_parameter import get_default_parameter
+
+
+@pytest.fixture(autouse=True)
+def setup_log_level_to_debug(cli_runner):
+    cli_runner.invoke(cli, ["--log-level", "DEBUG"])
 
 
 @pytest.fixture(scope="session")

--- a/tests/tools/default_parameter.py
+++ b/tests/tools/default_parameter.py
@@ -4,6 +4,8 @@ from typing import Any
 
 def get_default_parameter(obj, parameter_name: str) -> Any:
     """
+    https://stackoverflow.com/questions/12627118/get-a-function-arguments-default-value
+
     >>> get_default_parameter(signature, "follow_wrapped")
     True
     """


### PR DESCRIPTION
## Description

- click: add `invoke_without_command` on group command
- click: use `.set_default_command` to set default command on cli
- utest: refactoring for settings debug mode on logger globally for tests session
- 
## Checklist

- [x] Tests covering the new functionality have been added
- [x] Code builds clean without any errors or warnings
- [ ] Documentation has been updated
- [ ] Changes have been added to the `CHANGELOG.md`
- [ ] You added yourself to the `CONTRIBUTORS.md`
